### PR TITLE
stop vm

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1032,7 +1032,6 @@ export class LimaBackend extends events.EventEmitter implements VMBackend, VMExe
         // If we're in the middle of starting, also ignore the call to stop (from
         // the process terminating), as we do not want to shut down the VM in that
         // case.
-
         if (this.currentAction !== Action.NONE) {
             return;
         }
@@ -1046,6 +1045,7 @@ export class LimaBackend extends events.EventEmitter implements VMBackend, VMExe
 
                 if (status && status.status === 'Running') {
                     await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'containerd', 'stop');
+                    await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'subnet', 'stop');
                     await this.execCommand({ root: true }, '/sbin/fstrim', '/mnt/data');
                     await this.lima('stop', MACHINE_NAME);
                 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import * as settingsImpl from '../config/settingsImpl';
 
 let cfg: settings.Settings;
 let deploymentProfiles: settings.DeploymentProfileType = { defaults: {}, locked: {} };
+let gone = false; // when true indicates app is shutting down
 
 
 
@@ -91,7 +92,7 @@ app.whenReady().then(async () => {
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
 
-  //createWindow()
+  createWindow()
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
@@ -109,14 +110,15 @@ app.whenReady().then(async () => {
 
 })
 
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+app.on('window-all-closed', async () => {
+  try {
+    await vmmanager.stop()
+  } catch {
+  } finally {
     app.quit()
   }
-})
+});
+
 
 // In this file you can include the rest of your app"s specific main process
 // code. You can also put them in separate files and require them here.


### PR DESCRIPTION
This pull request includes several changes to the `src/backend/lima.ts` and `src/main/index.ts` files to improve the shutdown process and ensure proper service management. The most important changes include adding a new service stop command, modifying the window creation logic, and ensuring the VM manager stops before quitting the application.

Improvements to service management:

* [`src/backend/lima.ts`](diffhunk://#diff-614bfe66ccc65f91d90d156d11de4edbe0cd4a14b2389a1ed211f3ec9dbeca81R1048): Added a command to stop the 'subnet' service if it is started when shutting down the VM.

Enhancements to application shutdown:

* [`src/main/index.ts`](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR11): Introduced a new `gone` variable to indicate when the app is shutting down.
* [`src/main/index.ts`](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL94-R95): Modified the `app.whenReady` function to create the window immediately by uncommenting the `createWindow` function call.
* [`src/main/index.ts`](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL112-R121): Updated the `window-all-closed` event handler to ensure the VM manager stops before quitting the application.

Code cleanup:

* [`src/backend/lima.ts`](diffhunk://#diff-614bfe66ccc65f91d90d156d11de4edbe0cd4a14b2389a1ed211f3ec9dbeca81L1035): Removed an unnecessary comment to clean up the code.