### PR TITLE
Feat/win

### DIFF
--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -538,6 +538,7 @@ generateResolvConf = true
                         }
                     }
                     try {
+                        await this.execCommand('/sbin/rc-service', 'subnet', 'stop');
                         await this.stopService('local');
                     } catch (ex) {
                         // Do not allow errors here to prevent us from stopping.

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -80,7 +80,6 @@ export class Log {
       this.stream.on('open', resolve);
     });
     delete this._fdStream;
-    globalThis.console?.log(import.meta.env);
     // If we're running unit tests, output to the console rather than file.
     // However, _don't_ do so for end-to-end tests in Playwright.
     // We detect Playwright via an environment variable we set in scripts/e2e.ts

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -141,13 +141,21 @@ function getPaths(): Paths {
       });
       return new UnixPaths(pathsData);
     case 'win32':
+      let resourcesPath: string;
+
+      // If we are running as a script (i.e. yarn postinstall), electron.app is undefined
+      if (electron.app?.isPackaged) {
+        resourcesPath = path.join(process.resourcesPath, "app.asar.unpacked");
+      } else {
+        resourcesPath = electron.app?.getAppPath() || '';
+      }
       Object.assign(pathsData, {
         appHome: path.join(os.homedir(), 'AppData', 'Roaming', 'SubnetDesktop'),
         altAppHome: path.join(os.homedir(), 'AppData', 'Local', 'SubnetDesktop'),
         config: path.join(os.homedir(), 'AppData', 'Roaming', 'SubnetDesktop', 'config'),
         logs: path.join(os.homedir(), 'AppData', 'Roaming', 'SubnetDesktop', 'logs'),
         cache: path.join(os.homedir(), 'AppData', 'Local', 'SubnetDesktop', 'cache'),
-        resources: path.join(electron.app.getAppPath(), 'resources'),
+        resources: path.join(resourcesPath, 'resources'),
         extensionRoot: path.join(os.homedir(), 'AppData', 'Roaming', 'SubnetDesktop', 'extensions'),
         wslDistro: path.join(os.homedir(), 'AppData', 'Local', 'SubnetDesktop', 'wsl-distro'),
         wslDistroData: path.join(os.homedir(), 'AppData', 'Local', 'SubnetDesktop', 'wsl-distro-data'),


### PR DESCRIPTION
This pull request includes changes to improve the handling of service commands, logging, and path management in the codebase. The most important changes include stopping a specific service, removing unnecessary console log statements, and dynamically setting the resource path based on the environment.

Improvements to service command execution:

* [`src/backend/wsl.ts`](diffhunk://#diff-ebc2023607bda4219421a247402a226ddc2dabfc3913a373ff974bdca08111c0R541): Added a command to stop the 'subnet' service before stopping the 'local' service to ensure proper service management.

Enhancements to logging:

* [`src/utils/logging.ts`](diffhunk://#diff-0e07a00003db43dce30c641a3a8584a95408101eb80a17dc8f0e6aaf029b77c2L83): Removed an unnecessary console log statement to clean up the logging output.

Dynamic path management:

* [`src/utils/paths.ts`](diffhunk://#diff-f49f54e461a935d3cde70cb710c9052af5ac65a23e555322c09d8ef8429c9224R144-R158): Introduced logic to dynamically set the `resourcesPath` based on whether the application is packaged or running as a script, ensuring correct path resolution in different environments.